### PR TITLE
feat(backend): add upload API contract and FastAPI skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,9 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/

--- a/backend/FileUploadFeature.md
+++ b/backend/FileUploadFeature.md
@@ -1,0 +1,287 @@
+# File Upload API Contract (Sprint 1)
+
+Version: `v1`  
+Status: `reviewed`  
+Owner: `backend (YongShen)`  
+
+## 1) Scope and Decisions
+
+- Supported file types: `csv`, `xlsx`, `json`
+- Not supported: `pdf`
+- Backend stack: `Python + FastAPI + pandas`
+- Metastore: `SQLite` (future migration target: `Supabase/Postgres`)
+- Object storage: `MinIO` now, S3-compatible contract by design
+- Upload size limit: `25 MB`
+- Upload response includes: `dataset_id + schema + preview`
+- Session model: `session_id` (anonymous)
+
+## 2) Base API Rules
+
+- Base path: `/api/v1`
+- Content type:
+- Upload endpoint uses `multipart/form-data`
+- All non-upload responses use `application/json`
+- Time format: ISO-8601 UTC, e.g. `2026-02-28T18:25:43Z`
+- Error response shape is consistent for all endpoints
+
+## 3) Validation and Parse Constraints
+
+- Allowed extensions: `.csv`, `.xlsx`, `.json`
+- Allowed MIME types:
+- `text/csv`
+- `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`
+- `application/json`
+- Extension and MIME must both pass validation
+- Reject unsafe filename patterns:
+- path traversal (`../`, `..\\`)
+- control characters
+- blank filename
+- Max file size: `25 MB`
+- Parse timeout: `30 seconds`
+- Row cap: `200000` rows
+- Preview row default: `100`, max: `200`
+
+## 4) Canonical Data Model (DataFrame-like)
+
+- Canonical tabular object:
+- `columns`: ordered array of column names
+- `dtypes`: map of column name -> canonical type
+- `rows`: tabular records
+- Canonical type mapping:
+- `string`, `int`, `float`, `bool`, `datetime`, `unknown`
+- Missing values are normalized to `null`
+
+## 5) API Endpoints
+
+### 5.1 POST `/api/v1/upload`
+
+Uploads a dataset file, validates it, parses it, stores it, and returns metadata + preview.
+
+Request (`multipart/form-data`):
+
+- `file` (required): binary file
+- `session_id` (optional): string, max 128
+- `source` (optional): enum `user_upload | sample`, default `user_upload`
+- `preview_rows` (optional): integer `1..200`, default `100`
+
+Success `201`:
+
+```json
+{
+  "dataset_id": "ds_01JX5F8QH9P5Y7M3S4V8N2K6TQ",
+  "status": "ready",
+  "session_id": "sess_abc123",
+  "file_meta": {
+    "original_filename": "sales_2025.csv",
+    "extension": "csv",
+    "mime_type": "text/csv",
+    "size_bytes": 184321
+  },
+  "shape": {
+    "rows": 4821,
+    "columns": 9
+  },
+  "schema": [
+    {
+      "name": "order_id",
+      "dtype": "string",
+      "null_count": 0
+    },
+    {
+      "name": "order_date",
+      "dtype": "datetime",
+      "null_count": 2
+    },
+    {
+      "name": "total_amount",
+      "dtype": "float",
+      "null_count": 13
+    }
+  ],
+  "preview": [
+    {
+      "order_id": "A001",
+      "order_date": "2025-01-02T00:00:00Z",
+      "total_amount": 31.25
+    }
+  ],
+  "missing_summary": {
+    "rows_with_missing": 49,
+    "total_missing_cells": 77
+  },
+  "storage": {
+    "provider": "s3-compatible",
+    "bucket": "thinkabit-raw",
+    "object_key": "raw/2026/02/28/ds_01JX5F8QH9P5Y7M3S4V8N2K6TQ/sales_2025.csv"
+  },
+  "warnings": []
+}
+```
+
+Error examples:
+
+- `400` invalid multipart/form fields
+- `413` file too large
+- `415` unsupported extension/mime
+- `422` parse failed / non-tabular json / empty table
+- `500` storage/metastore/internal failure
+
+### 5.2 GET `/api/v1/datasets/{dataset_id}`
+
+Returns upload and parse metadata for a dataset.
+
+Success `200`:
+
+```json
+{
+  "dataset_id": "ds_01JX5F8QH9P5Y7M3S4V8N2K6TQ",
+  "status": "ready",
+  "session_id": "sess_abc123",
+  "file_meta": {
+    "original_filename": "sales_2025.csv",
+    "extension": "csv",
+    "mime_type": "text/csv",
+    "size_bytes": 184321
+  },
+  "shape": {
+    "rows": 4821,
+    "columns": 9
+  },
+  "created_at": "2026-02-28T18:25:43Z",
+  "updated_at": "2026-02-28T18:25:44Z"
+}
+```
+
+### 5.3 GET `/api/v1/datasets/{dataset_id}/schema`
+
+Returns inferred column schema and missing counts.
+
+Success `200`:
+
+```json
+{
+  "dataset_id": "ds_01JX5F8QH9P5Y7M3S4V8N2K6TQ",
+  "schema": [
+    {
+      "name": "order_id",
+      "dtype": "string",
+      "null_count": 0
+    },
+    {
+      "name": "total_amount",
+      "dtype": "float",
+      "null_count": 13
+    }
+  ]
+}
+```
+
+### 5.4 GET `/api/v1/datasets/{dataset_id}/preview`
+
+Returns tabular preview rows.
+
+Query params:
+
+- `limit` (optional): integer `1..200`, default `100`
+- `offset` (optional): integer `>=0`, default `0`
+
+Success `200`:
+
+```json
+{
+  "dataset_id": "ds_01JX5F8QH9P5Y7M3S4V8N2K6TQ",
+  "limit": 100,
+  "offset": 0,
+  "rows": [
+    {
+      "order_id": "A001",
+      "order_date": "2025-01-02T00:00:00Z",
+      "total_amount": 31.25
+    }
+  ]
+}
+```
+
+## 6) Unified Error Schema
+
+Every non-2xx response must follow:
+
+```json
+{
+  "error": {
+    "code": "UNSUPPORTED_FILE_TYPE",
+    "message": "Only csv, xlsx, json are allowed.",
+    "details": {
+      "allowed_extensions": [
+        "csv",
+        "xlsx",
+        "json"
+      ]
+    },
+    "request_id": "req_2S9M8P"
+  }
+}
+```
+
+Error code catalog:
+
+- `INVALID_MULTIPART` -> malformed multipart request (`400`)
+- `INVALID_REQUEST` -> field validation failed (`400`)
+- `FILE_TOO_LARGE` -> exceeds 25MB (`413`)
+- `UNSUPPORTED_FILE_TYPE` -> extension not allowed (`415`)
+- `MIME_TYPE_NOT_ALLOWED` -> mime not allowed (`415`)
+- `MIME_EXTENSION_MISMATCH` -> mime and extension mismatch (`415`)
+- `UNSAFE_FILENAME` -> invalid filename/path traversal (`400`)
+- `EMPTY_FILE` -> zero-byte file or no rows (`422`)
+- `ROW_LIMIT_EXCEEDED` -> exceeds row cap (`422`)
+- `PARSE_TIMEOUT` -> parsing exceeded timeout (`408`)
+- `PARSE_FAILED` -> parser error for valid type (`422`)
+- `DATASET_NOT_FOUND` -> unknown `dataset_id` (`404`)
+- `STORAGE_ERROR` -> MinIO/S3 write-read failure (`500`)
+- `METASTORE_ERROR` -> SQLite operation failure (`500`)
+- `INTERNAL_ERROR` -> fallback server error (`500`)
+
+## 7) Storage Contract (MinIO now, S3 later)
+
+Storage contract is strictly S3-compatible to keep migration to AWS S3 frictionless.
+
+- Raw bucket (current): `thinkabit-raw`
+- Canonical bucket (optional sprint 1): `thinkabit-canonical`
+- Object key format:
+- `raw/{yyyy}/{mm}/{dd}/{dataset_id}/{sanitized_filename}`
+- `canonical/{yyyy}/{mm}/{dd}/{dataset_id}/dataset.parquet`
+- Server stores and returns:
+- `provider` (`s3-compatible`)
+- `bucket`
+- `object_key`
+- direct MinIO endpoint is internal and not exposed in API response
+
+## 8) Metastore Fields (Contract-level)
+
+`datasets` table contract:
+
+- `dataset_id` (string, pk)
+- `session_id` (string, nullable)
+- `status` (enum: `uploaded | ready | failed`)
+- `original_filename` (string)
+- `extension` (string)
+- `mime_type` (string)
+- `size_bytes` (integer)
+- `row_count` (integer, nullable)
+- `column_count` (integer, nullable)
+- `storage_bucket_raw` (string)
+- `storage_key_raw` (string)
+- `storage_bucket_canonical` (string, nullable)
+- `storage_key_canonical` (string, nullable)
+- `error_code` (string, nullable)
+- `error_message` (string, nullable)
+- `created_at` (datetime UTC)
+- `updated_at` (datetime UTC)
+
+## 9) Non-goals in Sprint 1
+
+- Auth/JWT/user accounts
+- Presigned URL upload flow
+- Async job queue for parsing
+- Multi-file batch upload
+- PDF ingestion

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,19 @@
+# Backend Skeleton
+
+## Run locally
+
+1. Create virtual environment and install dependencies from `requirements.txt`.
+2. Start API:
+
+```bash
+uvicorn app.main:app --reload --app-dir backend
+```
+
+## Endpoints in skeleton
+
+- `GET /health`
+- `POST /api/v1/upload`
+
+Current upload route accepts multipart request and returns contract-compatible
+response shape. Validation, storage write, and dataframe parsing are scaffolded
+for later tasks.

--- a/backend/app/api/v1/upload.py
+++ b/backend/app/api/v1/upload.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, File, Form, UploadFile
+
+from app.core.config import DEFAULT_PREVIEW_ROWS
+from app.schemas.upload import SourceType, UploadResponse
+from app.services.upload_service import UploadService
+from app.services.upload_validator import UploadValidator
+
+
+router = APIRouter()
+upload_service = UploadService()
+upload_validator = UploadValidator()
+
+
+@router.post(
+    "/upload",
+    response_model=UploadResponse,
+    status_code=201,
+)
+async def upload_dataset(
+    file: UploadFile = File(...),
+    session_id: str | None = Form(default=None, max_length=128),
+    source: SourceType = Form(default="user_upload"),
+    preview_rows: int = Form(default=DEFAULT_PREVIEW_ROWS),
+) -> UploadResponse:
+    upload_validator.validate(file=file, preview_rows=preview_rows)
+
+    _ = source
+    return await upload_service.handle_upload(
+        file=file,
+        session_id=session_id,
+        preview_rows=preview_rows,
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,10 @@
+ALLOWED_EXTENSIONS = {"csv", "xlsx", "json"}
+ALLOWED_MIME_TYPES = {
+    "text/csv",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/json",
+}
+
+MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024
+DEFAULT_PREVIEW_ROWS = 100
+MAX_PREVIEW_ROWS = 200

--- a/backend/app/errors.py
+++ b/backend/app/errors.py
@@ -1,0 +1,46 @@
+from uuid import uuid4
+
+from fastapi import Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from app.schemas.upload import ErrorBody, ErrorResponse
+
+
+class APIError(Exception):
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        code: str,
+        message: str,
+        details: dict,
+        request_id: str,
+    ) -> None:
+        self.status_code = status_code
+        self.payload = ErrorResponse(
+            error=ErrorBody(
+                code=code,
+                message=message,
+                details=details,
+                request_id=request_id,
+            )
+        ).model_dump()
+
+
+async def api_error_handler(_: Request, exc: APIError) -> JSONResponse:
+    return JSONResponse(status_code=exc.status_code, content=exc.payload)
+
+
+async def request_validation_error_handler(
+    _: Request, exc: RequestValidationError
+) -> JSONResponse:
+    payload = ErrorResponse(
+        error=ErrorBody(
+            code="INVALID_REQUEST",
+            message="Request validation failed.",
+            details={"errors": exc.errors()},
+            request_id=f"req_{uuid4().hex[:8]}",
+        )
+    ).model_dump()
+    return JSONResponse(status_code=400, content=payload)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+
+from app.api.v1.upload import router as upload_router
+from app.errors import APIError, api_error_handler, request_validation_error_handler
+
+
+app = FastAPI(
+    title="ThinkABit File Upload API",
+    version="1.0.0",
+    description="Sprint 1 backend skeleton for file upload.",
+)
+
+app.include_router(upload_router, prefix="/api/v1")
+app.add_exception_handler(APIError, api_error_handler)
+app.add_exception_handler(RequestValidationError, request_validation_error_handler)
+
+
+@app.get("/health")
+def health_check() -> dict[str, str]:
+    return {"status": "ok"}

--- a/backend/app/schemas/upload.py
+++ b/backend/app/schemas/upload.py
@@ -1,0 +1,63 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+DatasetStatus = Literal["uploaded", "ready", "failed"]
+SourceType = Literal["user_upload", "sample"]
+DataType = Literal["string", "int", "float", "bool", "datetime", "unknown"]
+
+
+class FileMeta(BaseModel):
+    original_filename: str
+    extension: Literal["csv", "xlsx", "json"]
+    mime_type: str
+    size_bytes: int = Field(ge=0)
+
+
+class Shape(BaseModel):
+    rows: int = Field(ge=0)
+    columns: int = Field(ge=0)
+
+
+class ColumnSchema(BaseModel):
+    name: str
+    dtype: DataType
+    null_count: int = Field(ge=0)
+
+
+class MissingSummary(BaseModel):
+    rows_with_missing: int = Field(ge=0)
+    total_missing_cells: int = Field(ge=0)
+
+
+class StorageRef(BaseModel):
+    provider: Literal["s3-compatible"]
+    bucket: str
+    object_key: str
+
+
+class UploadResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    dataset_id: str
+    status: DatasetStatus
+    session_id: str | None = None
+    file_meta: FileMeta
+    shape: Shape
+    schema_: list[ColumnSchema] = Field(alias="schema")
+    preview: list[dict[str, Any]]
+    missing_summary: MissingSummary
+    storage: StorageRef
+    warnings: list[str]
+
+
+class ErrorBody(BaseModel):
+    code: str
+    message: str
+    details: dict[str, Any]
+    request_id: str
+
+
+class ErrorResponse(BaseModel):
+    error: ErrorBody

--- a/backend/app/services/upload_service.py
+++ b/backend/app/services/upload_service.py
@@ -1,0 +1,65 @@
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+from fastapi import UploadFile
+
+from app.schemas.upload import (
+    ColumnSchema,
+    FileMeta,
+    MissingSummary,
+    Shape,
+    StorageRef,
+    UploadResponse,
+)
+
+
+class UploadService:
+    def __init__(self, raw_bucket: str = "thinkabit-raw") -> None:
+        self.raw_bucket = raw_bucket
+
+    async def handle_upload(
+        self,
+        file: UploadFile,
+        session_id: str | None,
+        preview_rows: int,
+    ) -> UploadResponse:
+        dataset_id = f"ds_{uuid4().hex}"
+        extension = Path(file.filename or "").suffix.lower().lstrip(".")
+        now = datetime.now(UTC)
+
+        object_key = (
+            f"raw/{now.year:04d}/{now.month:02d}/{now.day:02d}/{dataset_id}/{file.filename}"
+        )
+
+        file_size = await self._estimate_file_size(file)
+        await file.seek(0)
+
+        return UploadResponse(
+            dataset_id=dataset_id,
+            status="uploaded",
+            session_id=session_id,
+            file_meta=FileMeta(
+                original_filename=file.filename or "unknown",
+                extension=extension,
+                mime_type=file.content_type or "application/octet-stream",
+                size_bytes=file_size,
+            ),
+            shape=Shape(rows=0, columns=0),
+            schema_=[],
+            preview=[],
+            missing_summary=MissingSummary(rows_with_missing=0, total_missing_cells=0),
+            storage=StorageRef(
+                provider="s3-compatible",
+                bucket=self.raw_bucket,
+                object_key=object_key,
+            ),
+            warnings=[
+                "Validation, storage write, and dataframe parsing are not implemented yet.",
+                f"Requested preview_rows={preview_rows} will be applied after parser integration.",
+            ],
+        )
+
+    async def _estimate_file_size(self, file: UploadFile) -> int:
+        content = await file.read()
+        return len(content)

--- a/backend/app/services/upload_validator.py
+++ b/backend/app/services/upload_validator.py
@@ -1,0 +1,70 @@
+from uuid import uuid4
+
+from fastapi import UploadFile
+
+from app.core.config import (
+    ALLOWED_EXTENSIONS,
+    ALLOWED_MIME_TYPES,
+    MAX_PREVIEW_ROWS,
+)
+from app.errors import APIError
+
+
+class UploadValidator:
+    def validate(self, file: UploadFile, preview_rows: int) -> None:
+        if preview_rows < 1 or preview_rows > MAX_PREVIEW_ROWS:
+            raise self._build_error(
+                code="INVALID_REQUEST",
+                message="preview_rows must be between 1 and 200.",
+                details={"field": "preview_rows"},
+                status_code=400,
+            )
+
+        if not file.filename:
+            raise self._build_error(
+                code="INVALID_REQUEST",
+                message="file must include a filename.",
+                details={"field": "file"},
+                status_code=400,
+            )
+
+        if any(char in file.filename for char in ("../", "..\\", "/", "\\")):
+            raise self._build_error(
+                code="UNSAFE_FILENAME",
+                message="Filename contains unsafe path characters.",
+                details={"field": "file.filename"},
+                status_code=400,
+            )
+
+        extension = file.filename.rsplit(".", 1)[-1].lower() if "." in file.filename else ""
+        if extension not in ALLOWED_EXTENSIONS:
+            raise self._build_error(
+                code="UNSUPPORTED_FILE_TYPE",
+                message="Only csv, xlsx, json are allowed.",
+                details={"allowed_extensions": sorted(ALLOWED_EXTENSIONS)},
+                status_code=415,
+            )
+
+        if file.content_type and file.content_type not in ALLOWED_MIME_TYPES:
+            raise self._build_error(
+                code="MIME_TYPE_NOT_ALLOWED",
+                message="MIME type is not allowed.",
+                details={"mime_type": file.content_type},
+                status_code=415,
+            )
+
+    def _build_error(
+        self,
+        *,
+        code: str,
+        message: str,
+        details: dict[str, object],
+        status_code: int,
+    ) -> APIError:
+        return APIError(
+            status_code=status_code,
+            code=code,
+            message=message,
+            details=details,
+            request_id=f"req_{uuid4().hex[:8]}",
+        )

--- a/backend/openapi/upload-api.v1.yaml
+++ b/backend/openapi/upload-api.v1.yaml
@@ -1,0 +1,549 @@
+openapi: 3.0.3
+info:
+  title: ThinkABit File Upload API
+  version: 1.0.0
+  description: >
+    Sprint 1 API contract for dataset upload, validation, parsing, and preview.
+    Storage backend is S3-compatible (MinIO now, AWS S3 later).
+servers:
+  - url: /api/v1
+    description: API v1 base path
+tags:
+  - name: Upload
+  - name: Datasets
+paths:
+  /upload:
+    post:
+      tags:
+        - Upload
+      summary: Upload and parse dataset
+      description: >
+        Accepts multipart upload for csv/xlsx/json, validates file safety and type,
+        parses into canonical tabular format, stores raw object, and returns schema
+        plus preview rows.
+      operationId: uploadDataset
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/UploadRequest'
+      responses:
+        '201':
+          description: Upload accepted and parsed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UploadResponse'
+              examples:
+                success:
+                  value:
+                    dataset_id: ds_01JX5F8QH9P5Y7M3S4V8N2K6TQ
+                    status: ready
+                    session_id: sess_abc123
+                    file_meta:
+                      original_filename: sales_2025.csv
+                      extension: csv
+                      mime_type: text/csv
+                      size_bytes: 184321
+                    shape:
+                      rows: 4821
+                      columns: 9
+                    schema:
+                      - name: order_id
+                        dtype: string
+                        null_count: 0
+                      - name: order_date
+                        dtype: datetime
+                        null_count: 2
+                      - name: total_amount
+                        dtype: float
+                        null_count: 13
+                    preview:
+                      - order_id: A001
+                        order_date: '2025-01-02T00:00:00Z'
+                        total_amount: 31.25
+                    missing_summary:
+                      rows_with_missing: 49
+                      total_missing_cells: 77
+                    storage:
+                      provider: s3-compatible
+                      bucket: thinkabit-raw
+                      object_key: raw/2026/02/28/ds_01JX5F8QH9P5Y7M3S4V8N2K6TQ/sales_2025.csv
+                    warnings: []
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '408':
+          $ref: '#/components/responses/ParseTimeoutError'
+        '413':
+          $ref: '#/components/responses/FileTooLargeError'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaError'
+        '422':
+          $ref: '#/components/responses/UnprocessableDataError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      x-constraints:
+        max_file_size_bytes: 26214400
+        parse_timeout_seconds: 30
+        row_cap: 200000
+  /datasets/{dataset_id}:
+    get:
+      tags:
+        - Datasets
+      summary: Get dataset metadata
+      operationId: getDataset
+      parameters:
+        - $ref: '#/components/parameters/DatasetId'
+      responses:
+        '200':
+          description: Dataset metadata returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DatasetMetadataResponse'
+        '404':
+          $ref: '#/components/responses/DatasetNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /datasets/{dataset_id}/schema:
+    get:
+      tags:
+        - Datasets
+      summary: Get inferred dataset schema
+      operationId: getDatasetSchema
+      parameters:
+        - $ref: '#/components/parameters/DatasetId'
+      responses:
+        '200':
+          description: Dataset schema returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DatasetSchemaResponse'
+        '404':
+          $ref: '#/components/responses/DatasetNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /datasets/{dataset_id}/preview:
+    get:
+      tags:
+        - Datasets
+      summary: Get preview rows
+      operationId: getDatasetPreview
+      parameters:
+        - $ref: '#/components/parameters/DatasetId'
+        - $ref: '#/components/parameters/PreviewLimit'
+        - $ref: '#/components/parameters/PreviewOffset'
+      responses:
+        '200':
+          description: Dataset preview returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DatasetPreviewResponse'
+        '404':
+          $ref: '#/components/responses/DatasetNotFoundError'
+        '422':
+          $ref: '#/components/responses/UnprocessableDataError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+components:
+  parameters:
+    DatasetId:
+      name: dataset_id
+      in: path
+      required: true
+      schema:
+        type: string
+        minLength: 1
+      description: Dataset identifier (for example, ds_01JX5F8QH9P5Y7M3S4V8N2K6TQ).
+    PreviewLimit:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 100
+      description: Number of preview rows to return.
+    PreviewOffset:
+      name: offset
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+      description: Offset into preview rows.
+  responses:
+    BadRequestError:
+      description: Request shape or field values are invalid.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            invalidRequest:
+              value:
+                error:
+                  code: INVALID_REQUEST
+                  message: preview_rows must be between 1 and 200.
+                  details:
+                    field: preview_rows
+                  request_id: req_2S9M8P
+    ParseTimeoutError:
+      description: Parsing exceeded configured timeout.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            parseTimeout:
+              value:
+                error:
+                  code: PARSE_TIMEOUT
+                  message: Parsing exceeded 30 seconds timeout.
+                  details: {}
+                  request_id: req_A1B2C3
+    FileTooLargeError:
+      description: Uploaded file exceeds max allowed size.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            tooLarge:
+              value:
+                error:
+                  code: FILE_TOO_LARGE
+                  message: File size exceeds 25MB limit.
+                  details:
+                    max_bytes: 26214400
+                  request_id: req_9Y8X7W
+    UnsupportedMediaError:
+      description: File extension or MIME type is not allowed.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            unsupportedType:
+              value:
+                error:
+                  code: UNSUPPORTED_FILE_TYPE
+                  message: Only csv, xlsx, json are allowed.
+                  details:
+                    allowed_extensions:
+                      - csv
+                      - xlsx
+                      - json
+                  request_id: req_6M5N4B
+    UnprocessableDataError:
+      description: File is syntactically valid but cannot be processed as a dataset.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            parseFailed:
+              value:
+                error:
+                  code: PARSE_FAILED
+                  message: Unable to parse JSON into tabular structure.
+                  details: {}
+                  request_id: req_Q2W3E4
+    DatasetNotFoundError:
+      description: Dataset ID does not exist.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            notFound:
+              value:
+                error:
+                  code: DATASET_NOT_FOUND
+                  message: Dataset not found.
+                  details:
+                    dataset_id: ds_missing
+                  request_id: req_Z7X6C5
+    InternalServerError:
+      description: Internal system failure.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            storageError:
+              value:
+                error:
+                  code: STORAGE_ERROR
+                  message: Failed to write object to storage backend.
+                  details: {}
+                  request_id: req_1A2S3D
+  schemas:
+    UploadRequest:
+      type: object
+      required:
+        - file
+      properties:
+        file:
+          type: string
+          format: binary
+          description: Input dataset file. Allowed extensions are csv, xlsx, json.
+        session_id:
+          type: string
+          maxLength: 128
+          description: Optional anonymous session identifier.
+        source:
+          type: string
+          enum:
+            - user_upload
+            - sample
+          default: user_upload
+        preview_rows:
+          type: integer
+          minimum: 1
+          maximum: 200
+          default: 100
+    UploadResponse:
+      type: object
+      required:
+        - dataset_id
+        - status
+        - file_meta
+        - shape
+        - schema
+        - preview
+        - missing_summary
+        - storage
+        - warnings
+      properties:
+        dataset_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/DatasetStatus'
+        session_id:
+          type: string
+          nullable: true
+        file_meta:
+          $ref: '#/components/schemas/FileMeta'
+        shape:
+          $ref: '#/components/schemas/Shape'
+        schema:
+          type: array
+          items:
+            $ref: '#/components/schemas/ColumnSchema'
+        preview:
+          type: array
+          items:
+            $ref: '#/components/schemas/PreviewRow'
+        missing_summary:
+          $ref: '#/components/schemas/MissingSummary'
+        storage:
+          $ref: '#/components/schemas/StorageRef'
+        warnings:
+          type: array
+          items:
+            type: string
+    DatasetMetadataResponse:
+      type: object
+      required:
+        - dataset_id
+        - status
+        - file_meta
+        - shape
+        - created_at
+        - updated_at
+      properties:
+        dataset_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/DatasetStatus'
+        session_id:
+          type: string
+          nullable: true
+        file_meta:
+          $ref: '#/components/schemas/FileMeta'
+        shape:
+          $ref: '#/components/schemas/Shape'
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    DatasetSchemaResponse:
+      type: object
+      required:
+        - dataset_id
+        - schema
+      properties:
+        dataset_id:
+          type: string
+        schema:
+          type: array
+          items:
+            $ref: '#/components/schemas/ColumnSchema'
+    DatasetPreviewResponse:
+      type: object
+      required:
+        - dataset_id
+        - limit
+        - offset
+        - rows
+      properties:
+        dataset_id:
+          type: string
+        limit:
+          type: integer
+        offset:
+          type: integer
+        rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/PreviewRow'
+    DatasetStatus:
+      type: string
+      enum:
+        - uploaded
+        - ready
+        - failed
+    FileMeta:
+      type: object
+      required:
+        - original_filename
+        - extension
+        - mime_type
+        - size_bytes
+      properties:
+        original_filename:
+          type: string
+        extension:
+          type: string
+          enum:
+            - csv
+            - xlsx
+            - json
+        mime_type:
+          type: string
+          enum:
+            - text/csv
+            - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+            - application/json
+        size_bytes:
+          type: integer
+          minimum: 0
+          maximum: 26214400
+    Shape:
+      type: object
+      required:
+        - rows
+        - columns
+      properties:
+        rows:
+          type: integer
+          minimum: 0
+        columns:
+          type: integer
+          minimum: 0
+    ColumnSchema:
+      type: object
+      required:
+        - name
+        - dtype
+        - null_count
+      properties:
+        name:
+          type: string
+        dtype:
+          $ref: '#/components/schemas/DataType'
+        null_count:
+          type: integer
+          minimum: 0
+    DataType:
+      type: string
+      enum:
+        - string
+        - int
+        - float
+        - bool
+        - datetime
+        - unknown
+    PreviewRow:
+      type: object
+      additionalProperties: true
+      description: One row from preview data as key-value pairs.
+    MissingSummary:
+      type: object
+      required:
+        - rows_with_missing
+        - total_missing_cells
+      properties:
+        rows_with_missing:
+          type: integer
+          minimum: 0
+        total_missing_cells:
+          type: integer
+          minimum: 0
+    StorageRef:
+      type: object
+      required:
+        - provider
+        - bucket
+        - object_key
+      properties:
+        provider:
+          type: string
+          enum:
+            - s3-compatible
+        bucket:
+          type: string
+        object_key:
+          type: string
+          description: >
+            Object key format:
+            raw/{yyyy}/{mm}/{dd}/{dataset_id}/{sanitized_filename}
+            or canonical/{yyyy}/{mm}/{dd}/{dataset_id}/dataset.parquet
+    ErrorResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          $ref: '#/components/schemas/ErrorBody'
+    ErrorBody:
+      type: object
+      required:
+        - code
+        - message
+        - details
+        - request_id
+      properties:
+        code:
+          type: string
+          enum:
+            - INVALID_MULTIPART
+            - INVALID_REQUEST
+            - FILE_TOO_LARGE
+            - UNSUPPORTED_FILE_TYPE
+            - MIME_TYPE_NOT_ALLOWED
+            - MIME_EXTENSION_MISMATCH
+            - UNSAFE_FILENAME
+            - EMPTY_FILE
+            - ROW_LIMIT_EXCEEDED
+            - PARSE_TIMEOUT
+            - PARSE_FAILED
+            - DATASET_NOT_FOUND
+            - STORAGE_ERROR
+            - METASTORE_ERROR
+            - INTERNAL_ERROR
+        message:
+          type: string
+        details:
+          type: object
+          additionalProperties: true
+        request_id:
+          type: string

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.116.1
+uvicorn[standard]==0.35.0
+pydantic==2.11.7
+python-multipart==0.0.20
+pandas==2.3.2
+pytest==8.4.2
+httpx

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from app.main import app  # noqa: E402
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(app)

--- a/backend/tests/test_upload_api.py
+++ b/backend/tests/test_upload_api.py
@@ -1,0 +1,118 @@
+from fastapi.testclient import TestClient
+
+
+def assert_error_schema(payload: dict) -> None:
+    assert "error" in payload
+    error = payload["error"]
+    assert isinstance(error, dict)
+    assert "code" in error
+    assert "message" in error
+    assert "details" in error
+    assert "request_id" in error
+
+
+def test_upload_valid_request_returns_structured_response(client: TestClient) -> None:
+    files = {"file": ("sample.csv", b"col1,col2\n1,2\n", "text/csv")}
+    data = {
+        "session_id": "sess_demo_1",
+        "source": "user_upload",
+        "preview_rows": "50",
+    }
+
+    response = client.post("/api/v1/upload", files=files, data=data)
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert "dataset_id" in payload
+    assert payload["status"] == "uploaded"
+    assert payload["session_id"] == "sess_demo_1"
+    assert "file_meta" in payload
+    assert payload["file_meta"]["extension"] == "csv"
+    assert "shape" in payload
+    assert "schema" in payload
+    assert "preview" in payload
+    assert "missing_summary" in payload
+    assert "storage" in payload
+    assert "warnings" in payload
+
+
+def test_upload_invalid_preview_rows_returns_error_schema(client: TestClient) -> None:
+    files = {"file": ("sample.csv", b"col1,col2\n1,2\n", "text/csv")}
+    response = client.post(
+        "/api/v1/upload",
+        files=files,
+        data={"preview_rows": "0"},
+    )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert_error_schema(payload)
+    assert payload["error"]["code"] == "INVALID_REQUEST"
+
+
+def test_upload_unsupported_extension_returns_error_schema(client: TestClient) -> None:
+    files = {"file": ("sample.txt", b"hello", "text/plain")}
+    response = client.post("/api/v1/upload", files=files)
+
+    assert response.status_code == 415
+    payload = response.json()
+    assert_error_schema(payload)
+    assert payload["error"]["code"] == "UNSUPPORTED_FILE_TYPE"
+
+
+def test_upload_disallowed_mime_returns_error_schema(client: TestClient) -> None:
+    files = {"file": ("sample.csv", b"col1,col2\n1,2\n", "application/pdf")}
+    response = client.post("/api/v1/upload", files=files)
+
+    assert response.status_code == 415
+    payload = response.json()
+    assert_error_schema(payload)
+    assert payload["error"]["code"] == "MIME_TYPE_NOT_ALLOWED"
+
+
+def test_upload_unsafe_filename_returns_error_schema(client: TestClient) -> None:
+    files = {"file": ("../sample.csv", b"col1,col2\n1,2\n", "text/csv")}
+    response = client.post("/api/v1/upload", files=files)
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert_error_schema(payload)
+    assert payload["error"]["code"] == "UNSAFE_FILENAME"
+
+
+def test_upload_missing_file_returns_error_schema(client: TestClient) -> None:
+    response = client.post("/api/v1/upload", data={"preview_rows": "10"})
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert_error_schema(payload)
+    assert payload["error"]["code"] == "INVALID_REQUEST"
+
+
+def test_upload_invalid_source_returns_error_schema(client: TestClient) -> None:
+    files = {"file": ("sample.csv", b"col1,col2\n1,2\n", "text/csv")}
+    response = client.post(
+        "/api/v1/upload",
+        files=files,
+        data={"source": "invalid_source"},
+    )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert_error_schema(payload)
+    assert payload["error"]["code"] == "INVALID_REQUEST"
+
+
+def test_upload_session_id_too_long_returns_error_schema(client: TestClient) -> None:
+    files = {"file": ("sample.csv", b"col1,col2\n1,2\n", "text/csv")}
+    long_session_id = "s" * 129
+    response = client.post(
+        "/api/v1/upload",
+        files=files,
+        data={"session_id": long_session_id},
+    )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert_error_schema(payload)
+    assert payload["error"]["code"] == "INVALID_REQUEST"


### PR DESCRIPTION
- Summary:
    - add Sprint 1 file upload API contract docs and OpenAPI spec
    - scaffold FastAPI backend with POST /api/v1/upload
    - add upload validator and unified error handlers
    - add API tests for valid/invalid schema consistency
- Validation: .venv/bin/python -m pytest backend/tests -q -> 8 passed