### PR TITLE
Add backend environment bootstrap workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+BACKEND_VENV_PYTHON := backend/.venv/bin/python
+
+.PHONY: backend-setup-minimal backend-setup-full backend-run backend-test
+
+backend-setup-minimal:
+	python3 backend/tools/bootstrap_env.py minimal
+
+backend-setup-full:
+	python3 backend/tools/bootstrap_env.py full
+
+backend-run:
+	@test -x $(BACKEND_VENV_PYTHON) || (echo "backend/.venv is missing. Run 'make backend-setup-minimal' or 'make backend-setup-full' first." && exit 1)
+	$(BACKEND_VENV_PYTHON) -m uvicorn app.main:app --reload --app-dir backend
+
+backend-test:
+	@test -x $(BACKEND_VENV_PYTHON) || (echo "backend/.venv is missing. Run 'make backend-setup-minimal' or 'make backend-setup-full' first." && exit 1)
+	$(BACKEND_VENV_PYTHON) -m pytest backend/tests

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,15 +1,19 @@
-# MinIO (local development)
+# Minimal mode defaults
+# `make backend-setup-minimal` keeps local integrations off so the API and tests
+# can run without MinIO or Supabase.
 MINIO_ENDPOINT=http://localhost:19000
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin
 MINIO_RAW_BUCKET=thinkabit-raw
 MINIO_SECURE=false
 MINIO_AUTO_CREATE_BUCKET=true
-MINIO_UPLOAD_ENABLED=true
+MINIO_UPLOAD_ENABLED=false
 
-# Supabase (used in later tasks)
-SUPABASE_URL=
-SUPABASE_SERVICE_ROLE_KEY=
-# URL-encode special characters in password (e.g. $ -> %24, % -> %25)
-DATABASE_URL=postgresql://postgres:<url-encoded-password>@<project-ref>.supabase.co:5432/postgres
-METASTORE_INSERT_ENABLED=true
+# Full mode requirements
+# `make backend-setup-full` turns these integrations on and expects the
+# following values to be replaced with real team-provided credentials.
+# SUPABASE_URL=https://your-project-ref.supabase.co
+# SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# URL-encode special characters in password before saving the real value.
+DATABASE_URL=postgresql://postgres:your-password@your-project-ref.supabase.co:5432/postgres
+METASTORE_INSERT_ENABLED=false

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,67 +1,108 @@
-# Backend Skeleton
+# Backend Quick Start
 
-## Run locally
+This backend bootstrap flow is supported on macOS and Linux.
 
-1. Create virtual environment and install dependencies from `requirements.txt`.
-2. (Optional but recommended) Start local MinIO:
+## Commands
 
-```bash
-docker compose -f backend/docker-compose.minio.yml up -d
-```
-
-3. Copy env template and adjust values if needed:
+Run all commands from the repository root:
 
 ```bash
-cp backend/.env.example backend/.env
+make backend-setup-minimal
+make backend-setup-full
+make backend-run
+make backend-test
 ```
 
-4. Start API:
+The backend virtual environment is created at `backend/.venv`.
+
+## Minimal Setup
+
+Use minimal mode when you only need the API and test suite.
 
 ```bash
-uvicorn app.main:app --reload --app-dir backend
+make backend-setup-minimal
 ```
 
-## Endpoints in skeleton
+This command:
+
+- creates `backend/.venv` if needed
+- installs `backend/requirements.txt`
+- creates `backend/.env` from `backend/.env.example` if it does not exist
+- sets `MINIO_UPLOAD_ENABLED=false`
+- sets `METASTORE_INSERT_ENABLED=false`
+
+After setup:
+
+```bash
+make backend-run
+make backend-test
+```
+
+## Full Setup
+
+Use full mode when you need local MinIO plus the remote Supabase/Postgres
+connection settings required by the backend metadata flow.
+
+```bash
+make backend-setup-full
+```
+
+This command:
+
+- runs the full minimal setup flow first
+- starts MinIO with `backend/docker-compose.minio.yml`
+- sets `MINIO_UPLOAD_ENABLED=true`
+- sets `METASTORE_INSERT_ENABLED=true`
+- validates `DATABASE_URL`
+
+If `DATABASE_URL` is still a placeholder, setup stops with a clear error after
+starting MinIO. The repository does not store real credentials. Your team must
+provide the real value separately and save it in `backend/.env`.
+
+## Running the API
+
+```bash
+make backend-run
+```
+
+This starts:
+
+```bash
+backend/.venv/bin/python -m uvicorn app.main:app --reload --app-dir backend
+```
+
+Health endpoint:
 
 - `GET /health`
-- `POST /api/v1/upload`
 
-Current upload route accepts multipart request and returns contract-compatible
-response shape. Validation, storage write, and dataframe parsing are scaffolded
-for later tasks.
+## Running Tests
 
-## Supabase Metadata Table (MVP)
+```bash
+make backend-test
+```
 
-Migration SQL file:
+This runs:
+
+```bash
+backend/.venv/bin/python -m pytest backend/tests
+```
+
+The test suite is hermetic for storage and metastore by default, so it does not
+require a running MinIO instance or live database connection.
+
+## Supabase Metadata Table
+
+If your team is using the metadata flow, apply the SQL files in `backend/supabase/` to the target Supabase project:
 
 - `backend/supabase/migrations/init_supabase_datasets_metadata_mvp.sql`
-
-Verification SQL file:
-
+- `backend/supabase/migrations/extend_datasets_metadata_for_dataset_get.sql`
 - `backend/supabase/verification/verify_datasets_metadata_mvp.sql`
-- `backend/supabase/migrations/extend_datasets_metadata_for_dataset_get.sql` (run before `GET /api/v1/datasets/{dataset_id}` work)
 
-Manual steps (Supabase):
+Manual settings used by the backend:
 
-1. Open Supabase SQL Editor for your target project.
-2. Run the migration SQL file.
-3. Run the verification SQL file and check:
-   - `public.datasets` exists with expected columns.
-   - enum `public.dataset_parse_status` has `uploaded/parsing/ready/failed`.
-   - trigger `trg_datasets_set_updated_at` exists and updates `updated_at`.
+- `DATABASE_URL`
+- `METASTORE_INSERT_ENABLED`
 
-Manual settings:
-
-- If you use a schema other than `public`, replace `public.` prefixes in both SQL files.
-- For later app integration (Task 8/9), configure:
-  - `SUPABASE_URL`
-  - `SUPABASE_SERVICE_ROLE_KEY`
-  - `DATABASE_URL`
-  - `METASTORE_INSERT_ENABLED`
-
-## MinIO Upload Notes
-
-- Upload to object storage is controlled by `MINIO_UPLOAD_ENABLED`.
-- `MINIO_UPLOAD_ENABLED=true` enables real `put_object` writes.
-- Default local endpoint is `http://localhost:19000` and bucket is `thinkabit-raw`.
-- Metadata insert to Supabase Postgres is controlled by `METASTORE_INSERT_ENABLED`.
+Additional Supabase-related values can stay in `.env` for future integrations,
+but the current backend runtime only requires `DATABASE_URL` for metastore
+writes.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,8 +1,11 @@
 import os
+from pathlib import Path
 
 from dotenv import load_dotenv
 
-load_dotenv()
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+load_dotenv(_BACKEND_ROOT / ".env")
 
 
 def _env_bool(name: str, default: bool) -> bool:

--- a/backend/tests/test_bootstrap_env.py
+++ b/backend/tests/test_bootstrap_env.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+from tools.bootstrap_env import (
+    REQUIRED_FULL_ENV_VARS,
+    configure_env_file,
+    find_missing_full_env_vars,
+)
+
+
+def test_configure_env_file_creates_minimal_env_from_example(tmp_path: Path) -> None:
+    example_path = tmp_path / ".env.example"
+    env_path = tmp_path / ".env"
+
+    example_path.write_text(
+        "\n".join(
+            [
+                "MINIO_UPLOAD_ENABLED=true",
+                "METASTORE_INSERT_ENABLED=true",
+                "SUPABASE_URL=https://your-project-ref.supabase.co",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    configure_env_file(env_path=env_path, example_path=example_path, mode="minimal")
+
+    assert env_path.exists()
+    content = env_path.read_text(encoding="utf-8")
+    assert "MINIO_UPLOAD_ENABLED=false" in content
+    assert "METASTORE_INSERT_ENABLED=false" in content
+    assert "SUPABASE_URL=https://your-project-ref.supabase.co" in content
+
+
+def test_configure_env_file_switches_existing_env_to_full_mode(tmp_path: Path) -> None:
+    example_path = tmp_path / ".env.example"
+    env_path = tmp_path / ".env"
+
+    example_path.write_text("MINIO_UPLOAD_ENABLED=false\n", encoding="utf-8")
+    env_path.write_text(
+        "\n".join(
+            [
+                "MINIO_UPLOAD_ENABLED=false",
+                "METASTORE_INSERT_ENABLED=false",
+                "CUSTOM_FLAG=kept",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    configure_env_file(env_path=env_path, example_path=example_path, mode="full")
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "MINIO_UPLOAD_ENABLED=true" in content
+    assert "METASTORE_INSERT_ENABLED=true" in content
+    assert "CUSTOM_FLAG=kept" in content
+
+
+def test_find_missing_full_env_vars_flags_blank_and_placeholder_values(
+    tmp_path: Path,
+) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "\n".join(
+            [
+                "SUPABASE_URL=https://your-project-ref.supabase.co",
+                "SUPABASE_SERVICE_ROLE_KEY=",
+                "DATABASE_URL=postgresql://postgres:your-password@your-project-ref.supabase.co:5432/postgres",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    missing = find_missing_full_env_vars(env_path)
+
+    assert missing == ["DATABASE_URL"]
+
+
+def test_find_missing_full_env_vars_accepts_realistic_values(tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "\n".join(
+            [
+                "SUPABASE_URL=https://your-project-ref.supabase.co",
+                "SUPABASE_SERVICE_ROLE_KEY=",
+                "DATABASE_URL=postgresql://postgres:encoded%24pass@db.example.com:5432/postgres",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert find_missing_full_env_vars(env_path) == []

--- a/backend/tools/bootstrap_env.py
+++ b/backend/tools/bootstrap_env.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+REQUIRED_FULL_ENV_VARS = ("DATABASE_URL",)
+
+ENV_FLAG_VALUES = {
+    "minimal": {
+        "MINIO_UPLOAD_ENABLED": "false",
+        "METASTORE_INSERT_ENABLED": "false",
+    },
+    "full": {
+        "MINIO_UPLOAD_ENABLED": "true",
+        "METASTORE_INSERT_ENABLED": "true",
+    },
+}
+
+PLACEHOLDER_VALUES = {
+    "DATABASE_URL": {
+        "",
+        "postgresql://postgres:your-password@your-project-ref.supabase.co:5432/postgres",
+    },
+}
+
+
+def parse_env_file(env_path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not env_path.exists():
+        return values
+
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in raw_line:
+            continue
+        key, value = raw_line.split("=", 1)
+        values[key.strip()] = value.strip()
+
+    return values
+
+
+def upsert_env_value(content: str, key: str, value: str) -> str:
+    lines = content.splitlines()
+    replaced = False
+    updated_lines: list[str] = []
+
+    for line in lines:
+        if line.startswith(f"{key}="):
+            updated_lines.append(f"{key}={value}")
+            replaced = True
+        else:
+            updated_lines.append(line)
+
+    if not replaced:
+        updated_lines.append(f"{key}={value}")
+
+    return "\n".join(updated_lines).rstrip() + "\n"
+
+
+def configure_env_file(*, env_path: Path, example_path: Path, mode: str) -> None:
+    if not env_path.exists():
+        env_path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    content = env_path.read_text(encoding="utf-8")
+    for key, value in ENV_FLAG_VALUES[mode].items():
+        content = upsert_env_value(content, key, value)
+    env_path.write_text(content, encoding="utf-8")
+
+
+def find_missing_full_env_vars(env_path: Path) -> list[str]:
+    values = parse_env_file(env_path)
+    missing: list[str] = []
+
+    for key in REQUIRED_FULL_ENV_VARS:
+        value = values.get(key, "").strip()
+        if value in PLACEHOLDER_VALUES[key]:
+            missing.append(key)
+
+    return missing
+
+
+def require_command(name: str) -> None:
+    if shutil.which(name) is None:
+        raise SystemExit(
+            f"Missing required command: {name}. Install it and rerun this setup."
+        )
+
+
+def run_command(args: list[str], *, cwd: Path) -> None:
+    subprocess.run(args, cwd=cwd, check=True)
+
+
+def ensure_virtualenv(venv_path: Path) -> None:
+    if venv_path.exists():
+        return
+    run_command([sys.executable, "-m", "venv", str(venv_path)], cwd=venv_path.parent)
+
+
+def install_requirements(*, venv_python: Path, requirements_path: Path, cwd: Path) -> None:
+    run_command([str(venv_python), "-m", "pip", "install", "-r", str(requirements_path)], cwd=cwd)
+
+
+def start_minio(*, repo_root: Path) -> None:
+    run_command(
+        [
+            "docker",
+            "compose",
+            "-f",
+            "backend/docker-compose.minio.yml",
+            "up",
+            "-d",
+        ],
+        cwd=repo_root,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Bootstrap ThinkABit backend development environments."
+    )
+    parser.add_argument("mode", choices=("minimal", "full"))
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    backend_root = repo_root / "backend"
+    env_path = backend_root / ".env"
+    example_path = backend_root / ".env.example"
+    venv_path = backend_root / ".venv"
+    venv_python = venv_path / "bin" / "python"
+    requirements_path = backend_root / "requirements.txt"
+
+    try:
+        require_command("python3")
+        ensure_virtualenv(venv_path)
+        install_requirements(
+            venv_python=venv_python,
+            requirements_path=requirements_path,
+            cwd=repo_root,
+        )
+        configure_env_file(env_path=env_path, example_path=example_path, mode=args.mode)
+
+        if args.mode == "minimal":
+            print("Minimal backend setup complete.")
+            print("Next steps:")
+            print("  make backend-run")
+            print("  make backend-test")
+            return 0
+
+        require_command("docker")
+        run_command(["docker", "compose", "version"], cwd=repo_root)
+        start_minio(repo_root=repo_root)
+
+        missing_vars = find_missing_full_env_vars(env_path)
+        if missing_vars:
+            print("Full backend setup is incomplete.")
+            print(
+                "MinIO is running, but these backend/.env values still need real values:"
+            )
+            for key in missing_vars:
+                print(f"  - {key}")
+            return 1
+
+        print("Full backend setup complete.")
+        print("Next steps:")
+        print("  make backend-run")
+        print("  make backend-test")
+        return 0
+    except subprocess.CalledProcessError as exc:
+        print(
+            "Setup command failed:",
+            " ".join(str(part) for part in exc.cmd),
+            file=sys.stderr,
+        )
+        return exc.returncode or 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add root Makefile targets for backend setup, run, and test flows
- add a backend bootstrap helper plus env validation tests for minimal/full modes
- update backend env/docs and make config loading use backend/.env from repo-root commands

## Test Plan
- make backend-setup-minimal
- make backend-test
- make backend-run
- curl -s http://127.0.0.1:8000/health
- make backend-setup-full
