### PR TITLE
[codex] Add session dataset list API

### DIFF
--- a/backend/FileUploadFeature.md
+++ b/backend/FileUploadFeature.md
@@ -161,7 +161,53 @@ Success `200`:
 }
 ```
 
-### 5.3 GET `/api/v1/datasets/{dataset_id}/schema`
+### 5.3 GET `/api/v1/sessions/{session_id}/datasets`
+
+Returns all datasets associated with the provided anonymous session ID, sorted
+by `created_at` from oldest to newest. This endpoint is intended for frontend
+session resume flows and dataset pickers.
+
+Success `200`:
+
+```json
+{
+  "datasets": [
+    {
+      "dataset_id": "ds_01JX5F8QH9P5Y7M3S4V8N2K6TQ",
+      "name": "sales_2025.csv",
+      "status": "ready",
+      "schema": [
+        {
+          "name": "order_id",
+          "dtype": "string",
+          "null_count": 0
+        },
+        {
+          "name": "total_amount",
+          "dtype": "float",
+          "null_count": 13
+        }
+      ],
+      "row_count": 4821,
+      "created_at": "2026-02-28T18:25:43Z"
+    }
+  ]
+}
+```
+
+If the session has no datasets, the endpoint returns `200` with an empty list:
+
+```json
+{
+  "datasets": []
+}
+```
+
+Error examples:
+
+- `500` metastore/internal failure
+
+### 5.4 GET `/api/v1/datasets/{dataset_id}/schema`
 
 Returns inferred column schema and missing counts.
 
@@ -185,7 +231,7 @@ Success `200`:
 }
 ```
 
-### 5.4 GET `/api/v1/datasets/{dataset_id}/preview`
+### 5.5 GET `/api/v1/datasets/{dataset_id}/preview`
 
 Returns tabular preview rows.
 
@@ -211,7 +257,7 @@ Success `200`:
 }
 ```
 
-### 5.5 DELETE `/api/v1/datasets/{dataset_id}`
+### 5.6 DELETE `/api/v1/datasets/{dataset_id}`
 
 Deletes dataset metadata from Supabase and deletes the raw object from MinIO.
 
@@ -324,6 +370,7 @@ Storage contract is strictly S3-compatible to keep migration to AWS S3 frictionl
 | P0 | MinIO - `put_object(file_bytes, key, content_type)` | 5 |
 | P0 | Supabase - record insert | 5 |
 | P0 | Implement `GET /api/v1/datasets/{dataset_id}` | 4 |
+| P0 | Implement `GET /api/v1/sessions/{session_id}/datasets` | 4 |
 | P0 | Implement `GET /api/v1/datasets/{dataset_id}/schema` | 4 |
 | P0 | Implement `GET /api/v1/datasets/{dataset_id}/preview` | 6 |
 | P0 | Implement `DELETE /api/v1/datasets/{dataset_id}` | 6 |
@@ -335,15 +382,15 @@ Storage contract is strictly S3-compatible to keep migration to AWS S3 frictionl
 | P2 | Advanced content safety checks (zip-bomb / malicious payload patterns) | 12 |
 | P2 | Soft-delete and periodic orphan cleanup jobs | 14 |
 
-Total estimated implementation time: `96 hours`.
+Total estimated implementation time: `100 hours`.
 
 ## 11) Sprint Plan (20h each, by priority)
 
 | Sprint | Scope | Planned Hours |
 | --- | --- | ---: |
 | Sprint 2 | Supabase table init (6) + MinIO put (5) + Supabase insert (5) + `GET /datasets/{dataset_id}` (4) | 20 |
-| Sprint 3 | `GET /datasets/{dataset_id}/schema` (4) + `GET /datasets/{dataset_id}/preview` (6) + `DELETE /datasets/{dataset_id}` (6) + Supabase delete (4) | 20 |
-| Sprint 4 | MinIO delete (4) + MinIO get (4) + Integration test MinIO->Metastore (8) + stabilization buffer (4) | 20 |
+| Sprint 3 | `GET /sessions/{session_id}/datasets` (4) + `GET /datasets/{dataset_id}/schema` (4) + `GET /datasets/{dataset_id}/preview` (6) + `DELETE /datasets/{dataset_id}` (6) | 20 |
+| Sprint 4 | MinIO delete (4) + Supabase delete (4) + MinIO get (4) + Integration test MinIO->Metastore (8) | 20 |
 | Sprint 5 | Async parse pipeline (14) + Content safety checks phase 1 (6) | 20 |
 | Sprint 6 | Content safety checks phase 2 (6) + Soft-delete + orphan cleanup jobs (14) | 20 |
 

--- a/backend/app/api/v1/upload.py
+++ b/backend/app/api/v1/upload.py
@@ -13,6 +13,8 @@ from app.schemas.upload import (
     DatasetSchemaResponse,
     FileMeta,
     Shape,
+    SessionDatasetInfo,
+    SessionDatasetsResponse,
     SourceType,
     UploadResponse,
 )
@@ -137,6 +139,38 @@ def get_dataset(dataset_id: str) -> DatasetMetadataResponse:
         shape=Shape(rows=record.row_count, columns=record.column_count),
         created_at=record.created_at,
         updated_at=record.updated_at,
+    )
+
+
+@router.get(
+    "/sessions/{session_id}/datasets",
+    response_model=SessionDatasetsResponse,
+    status_code=200,
+)
+def list_session_datasets(session_id: str) -> SessionDatasetsResponse:
+    try:
+        records = metastore_service.list_datasets_for_session(session_id)
+    except Exception as exc:
+        raise APIError(
+            status_code=500,
+            code="METASTORE_ERROR",
+            message="Failed to read metadata from metastore backend.",
+            details={"reason": str(exc)[:200]},
+            request_id=f"req_{uuid4().hex[:8]}",
+        ) from exc
+
+    return SessionDatasetsResponse(
+        datasets=[
+            SessionDatasetInfo(
+                dataset_id=record.dataset_id,
+                name=record.name,
+                status=record.parse_status,
+                schema_=[ColumnSchema(**column) for column in record.schema_json],
+                row_count=record.row_count,
+                created_at=record.created_at,
+            )
+            for record in records
+        ]
     )
 
 

--- a/backend/app/schemas/upload.py
+++ b/backend/app/schemas/upload.py
@@ -63,6 +63,21 @@ class DatasetMetadataResponse(BaseModel):
     updated_at: datetime
 
 
+class SessionDatasetInfo(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    dataset_id: str
+    name: str
+    status: DatasetStatus
+    schema_: list[ColumnSchema] = Field(alias="schema")
+    row_count: int = Field(ge=0)
+    created_at: datetime
+
+
+class SessionDatasetsResponse(BaseModel):
+    datasets: list[SessionDatasetInfo]
+
+
 class DatasetSchemaResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 

--- a/backend/app/services/metastore_service.py
+++ b/backend/app/services/metastore_service.py
@@ -44,6 +44,16 @@ class DatasetSchemaRecord:
 
 
 @dataclass
+class SessionDatasetRecord:
+    dataset_id: str
+    name: str
+    parse_status: str
+    schema_json: list[dict[str, str | int]]
+    row_count: int
+    created_at: datetime
+
+
+@dataclass
 class DatasetPreviewSourceRecord:
     dataset_id: str
     extension: str
@@ -147,6 +157,40 @@ class MetastoreService:
             created_at=row[9],
             updated_at=row[10],
         )
+
+    def list_datasets_for_session(self, session_id: str) -> list[SessionDatasetRecord]:
+        if not self.database_url:
+            raise RuntimeError("DATABASE_URL is not configured")
+
+        query = """
+            SELECT
+                dataset_id,
+                original_filename,
+                parse_status::text,
+                COALESCE(schema_json, '[]'::jsonb),
+                COALESCE(row_count, 0),
+                created_at
+            FROM public.datasets
+            WHERE session_id = %s
+            ORDER BY created_at ASC
+        """
+
+        with psycopg2.connect(self.database_url) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(query, (session_id,))
+                rows = cursor.fetchall()
+
+        return [
+            SessionDatasetRecord(
+                dataset_id=row[0],
+                name=row[1],
+                parse_status=row[2],
+                schema_json=row[3],
+                row_count=int(row[4]),
+                created_at=row[5],
+            )
+            for row in rows
+        ]
 
     def get_dataset_schema(self, dataset_id: str) -> DatasetSchemaRecord | None:
         if not self.database_url:

--- a/backend/openapi/upload-api.v1.yaml
+++ b/backend/openapi/upload-api.v1.yaml
@@ -88,6 +88,48 @@ paths:
         max_file_size_bytes: 26214400
         parse_timeout_seconds: 30
         row_cap: 200000
+  /sessions/{session_id}/datasets:
+    get:
+      tags:
+        - Datasets
+      summary: List datasets for a session
+      description: >
+        Returns datasets associated with the provided anonymous session ID,
+        sorted by creation time from oldest to newest.
+      operationId: listSessionDatasets
+      parameters:
+        - name: session_id
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+          description: Anonymous session identifier from the upload flow.
+      responses:
+        '200':
+          description: Session datasets returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionDatasetsResponse'
+              examples:
+                success:
+                  value:
+                    datasets:
+                      - dataset_id: ds_01JX5F8QH9P5Y7M3S4V8N2K6TQ
+                        name: sales_2025.csv
+                        status: ready
+                        schema:
+                          - name: order_id
+                            dtype: string
+                            null_count: 0
+                        row_count: 4821
+                        created_at: '2026-02-28T18:25:43Z'
+                empty:
+                  value:
+                    datasets: []
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /datasets/{dataset_id}:
     get:
       tags:
@@ -426,6 +468,42 @@ components:
         updated_at:
           type: string
           format: date-time
+    SessionDatasetInfo:
+      type: object
+      required:
+        - dataset_id
+        - name
+        - status
+        - schema
+        - row_count
+        - created_at
+      properties:
+        dataset_id:
+          type: string
+        name:
+          type: string
+          description: Original uploaded filename.
+        status:
+          $ref: '#/components/schemas/DatasetStatus'
+        schema:
+          type: array
+          items:
+            $ref: '#/components/schemas/ColumnSchema'
+        row_count:
+          type: integer
+          minimum: 0
+        created_at:
+          type: string
+          format: date-time
+    SessionDatasetsResponse:
+      type: object
+      required:
+        - datasets
+      properties:
+        datasets:
+          type: array
+          items:
+            $ref: '#/components/schemas/SessionDatasetInfo'
     DatasetSchemaResponse:
       type: object
       required:

--- a/backend/tests/test_upload_api.py
+++ b/backend/tests/test_upload_api.py
@@ -506,6 +506,97 @@ def test_get_dataset_metastore_error_returns_metastore_error(
     assert payload["error"]["code"] == "METASTORE_ERROR"
 
 
+def test_list_session_datasets_returns_dataset_list_sorted_by_created_at(
+    client: TestClient, monkeypatch
+) -> None:
+    older = datetime(2026, 1, 1, 10, 0, tzinfo=UTC)
+    newer = datetime(2026, 1, 2, 10, 0, tzinfo=UTC)
+    mock_metastore = Mock()
+    mock_metastore.list_datasets_for_session.return_value = [
+        type(
+            "SessionDatasetRecord",
+            (),
+            {
+                "dataset_id": "ds_old",
+                "name": "old.csv",
+                "parse_status": "ready",
+                "schema_json": [
+                    {"name": "age", "dtype": "int", "null_count": 0},
+                ],
+                "row_count": 10,
+                "created_at": older,
+            },
+        )(),
+        type(
+            "SessionDatasetRecord",
+            (),
+            {
+                "dataset_id": "ds_new",
+                "name": "new.csv",
+                "parse_status": "failed",
+                "schema_json": [],
+                "row_count": 0,
+                "created_at": newer,
+            },
+        )(),
+    ]
+    monkeypatch.setattr(upload_module, "metastore_service", mock_metastore)
+
+    response = client.get("/api/v1/sessions/sess_abc/datasets")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["datasets"] == [
+        {
+            "dataset_id": "ds_old",
+            "name": "old.csv",
+            "status": "ready",
+            "schema": [{"name": "age", "dtype": "int", "null_count": 0}],
+            "row_count": 10,
+            "created_at": older.isoformat().replace("+00:00", "Z"),
+        },
+        {
+            "dataset_id": "ds_new",
+            "name": "new.csv",
+            "status": "failed",
+            "schema": [],
+            "row_count": 0,
+            "created_at": newer.isoformat().replace("+00:00", "Z"),
+        },
+    ]
+    mock_metastore.list_datasets_for_session.assert_called_once_with("sess_abc")
+
+
+def test_list_session_datasets_empty_session_returns_empty_list(
+    client: TestClient, monkeypatch
+) -> None:
+    mock_metastore = Mock()
+    mock_metastore.list_datasets_for_session.return_value = []
+    monkeypatch.setattr(upload_module, "metastore_service", mock_metastore)
+
+    response = client.get("/api/v1/sessions/sess_empty/datasets")
+
+    assert response.status_code == 200
+    assert response.json() == {"datasets": []}
+
+
+def test_list_session_datasets_metastore_error_returns_metastore_error(
+    client: TestClient, monkeypatch
+) -> None:
+    mock_metastore = Mock()
+    mock_metastore.list_datasets_for_session.side_effect = RuntimeError(
+        "simulated session list failure"
+    )
+    monkeypatch.setattr(upload_module, "metastore_service", mock_metastore)
+
+    response = client.get("/api/v1/sessions/sess_abc/datasets")
+
+    assert response.status_code == 500
+    payload = response.json()
+    assert_error_schema(payload)
+    assert payload["error"]["code"] == "METASTORE_ERROR"
+
+
 def test_get_dataset_schema_returns_schema_payload(
     client: TestClient, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add `GET /api/v1/sessions/{session_id}/datasets` for frontend session dataset lookup
- return dataset id, original filename, status, schema, row count, and created timestamp sorted by `created_at` ascending
- document the endpoint in OpenAPI and `backend/FileUploadFeature.md`
- add tests for success, empty sessions, and metastore failures

## Validation
- `.venv/bin/python -m pytest backend/tests`
- `.venv/bin/python -c "import yaml; yaml.safe_load(open('backend/openapi/upload-api.v1.yaml'))"`